### PR TITLE
Use Files and Ranks to get SquareName type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,13 +1,12 @@
+import { FILES, RANKS } from './util';
+
+export type File = typeof FILES[number];
+
+export type Rank = typeof RANKS[number];
+
 export type Square = number;
 
-export type SquareName = 'a1' | 'b1' | 'c1' | 'd1' | 'e1' | 'f1' | 'g1' | 'h1' |
-                         'a2' | 'b2' | 'c2' | 'd2' | 'e2' | 'f2' | 'g2' | 'h2' |
-                         'a3' | 'b3' | 'c3' | 'd3' | 'e3' | 'f3' | 'g3' | 'h3' |
-                         'a4' | 'b4' | 'c4' | 'd4' | 'e4' | 'f4' | 'g4' | 'h4' |
-                         'a5' | 'b5' | 'c5' | 'd5' | 'e5' | 'f5' | 'g5' | 'h5' |
-                         'a6' | 'b6' | 'c6' | 'd6' | 'e6' | 'f6' | 'g6' | 'h6' |
-                         'a7' | 'b7' | 'c7' | 'd7' | 'e7' | 'f7' | 'g7' | 'h7' |
-                         'a8' | 'b8' | 'c8' | 'd8' | 'e8' | 'f8' | 'g8' | 'h8';
+export type SquareName = `${File}${Rank}`;
 
 export type BySquare<T> = T[];
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,7 @@
 import { Color, Square, Role, Move, isDrop, SquareName } from './types';
 
-export const FILES: readonly string[] = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
-export const RANKS: readonly string[] = ['1', '2', '3', '4', '5', '6', '7', '8'];
+export const FILES = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'] as const;
+export const RANKS = ['1', '2', '3', '4', '5', '6', '7', '8'] as const;
 
 export function defined<A>(v: A | undefined): v is A {
   return v !== undefined;


### PR DESCRIPTION
I left the FILES and RANKS arrays in the /util.ts file, but it may be appropriate to move them to the /types.ts file. I wasn't sure what you'd prefer.