### PR TITLE
Export Racing Kings board from variant.ts

### DIFF
--- a/src/variant.ts
+++ b/src/variant.ts
@@ -346,7 +346,7 @@ export class ThreeCheck extends Chess {
   }
 }
 
-class RacingKings extends Chess {
+export class RacingKings extends Chess {
   protected constructor() {
     super('racingkings');
   }


### PR DESCRIPTION
Nice project.

I'm trying to bundle it up partially with `rollup` and when creating variant boards, `RacingKings` board unlike other variant boards is not exported from `variant.ts`. Judging from all other boards being exported and the absence of this in the case of `RacingKIngs` causing a bundling error, I assume this is not intentional and I submit this PR to export it.