### PR TITLE
Let file be specified as a number in parseSquare

### DIFF
--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -4,6 +4,11 @@ test('parse uci', () => {
   expect(parseUci('a1a2')).toEqual({ from: 0, to: 8 });
   expect(parseUci('h7h8k')).toEqual({ from: 55, to: 63, promotion: 'king' });
   expect(parseUci('P@h1')).toEqual({ role: 'pawn', to: 7 });
+  expect(parseUci('11a2')).toEqual({ from: 0, to: 8 });
+  expect(parseUci('1112')).toEqual({ from: 0, to: 8 });
+  expect(parseUci('a112')).toEqual({ from: 0, to: 8 });
+  expect(parseUci('a112')).toEqual({ from: 0, to: 8 });
+  expect(parseUci('7888')).toEqual({ from: 62, to: 63 });
 });
 
 test('make uci', () => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -50,7 +50,8 @@ export function parseSquare(str: SquareName): Square;
 export function parseSquare(str: string): Square | undefined;
 export function parseSquare(str: string): Square | undefined {
   if (str.length !== 2) return;
-  const file = str.charCodeAt(0) - 'a'.charCodeAt(0);
+  const firstChar = str.charCodeAt(0);
+  const file = firstChar - 'a'.charCodeAt(0) >= 0 ? firstChar - 'a'.charCodeAt(0) : firstChar - '1'.charCodeAt(0);
   const rank = str.charCodeAt(1) - '1'.charCodeAt(0);
   if (file < 0 || file >= 8 || rank < 0 || rank >= 8) return;
   return file + 8 * rank;


### PR DESCRIPTION
This change is intended to make it easier to play blindfolded chess, since you can enter your movements by placing one finger over each number 1-8 without the need to move them.