### PR TITLE
Promote pawns to queens if no promotion is specified

### DIFF
--- a/src/chess.test.ts
+++ b/src/chess.test.ts
@@ -114,6 +114,14 @@ test('test illegal promotion', () => {
   expect(pos.isLegal({ from: 12, to: 20, promotion: 'queen' })).toBe(false);
 });
 
+test('default promotion to queen', () => {
+  const pos = Chess.fromSetup(parseFen('4k3/7P/8/8/8/8/8/4K3 w - - 0 1').unwrap()).unwrap();
+  const move = { from: 55, to: 63 };
+  expect(pos.isLegal(move)).toBe(true);
+  pos.play(move);
+  expect(makeFen(pos.toSetup())).toBe('4k2Q/8/8/8/8/8/8/4K3 b - - 0 1');
+});
+
 test('starting perft', () => {
   const pos = Chess.default();
   expect(perft(pos, 0, false)).toBe(1);

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -421,7 +421,7 @@ export abstract class Position {
     } else {
       if (move.promotion === 'pawn') return false;
       if (move.promotion === 'king' && this.rules !== 'antichess') return false;
-      if (!!move.promotion !== (this.board.pawn.has(move.from) && SquareSet.backranks().has(move.to))) return false;
+      if (!!move.promotion && !(this.board.pawn.has(move.from) && SquareSet.backranks().has(move.to))) return false;
       const dests = this.dests(move.from, ctx);
       return dests.has(move.to) || dests.has(normalizeMove(this, move).to);
     }
@@ -496,6 +496,9 @@ export abstract class Position {
         }
         if (move.promotion) {
           piece.role = move.promotion;
+          piece.promoted = !!this.pockets;
+        } else if (SquareSet.backranks().has(move.to)) {
+          piece.role = 'queen';
           piece.promoted = !!this.pockets;
         }
       } else if (piece.role === 'rook') {


### PR DESCRIPTION
In scalachess, moving a pawn to the backrank automatically promotes it to a queen.
In chessops, it results in ERR_PAWNS_ON_BACKRANK.

This pull request makes chessops behave more like scalachess with pawn promotions.

This is intended to fix https://lichess.org/forum/lichess-feedback/avoidable-bug-with-puzzles-in-blind-mode.