### PR TITLE
add subtract method to Material and MaterialSide

### DIFF
--- a/src/setup.ts
+++ b/src/setup.ts
@@ -40,6 +40,12 @@ export class MaterialSide implements ByRole<number> {
     return m;
   }
 
+  subtract(other: MaterialSide): MaterialSide {
+    const m = new MaterialSide();
+    for (const role of ROLES) m[role] = this[role] - other[role];
+    return m;
+  }
+
   nonEmpty(): boolean {
     return ROLES.some(role => this[role] > 0);
   }
@@ -85,6 +91,10 @@ export class Material implements ByColor<MaterialSide> {
 
   add(other: Material): Material {
     return new Material(this.white.add(other.white), this.black.add(other.black));
+  }
+
+  subtract(other: Material): Material {
+    return new Material(this.white.subtract(other.white), this.black.subtract(other.black));
   }
 
   count(role: Role): number {


### PR DESCRIPTION
This PR adds a subtract method to Material and MaterialSide.


For now, i use this when i want to get the captured material :

```
function subtractMaterialSide(
  left: MaterialSide,
  right: MaterialSide
): MaterialSide {
  const m = MaterialSide.empty();
  for (const role of ROLES) m[role] = left[role] - right[role];
  return m;
}

function subtractMaterial(left: Material, right: Material): Material {
  return new Material(
    subtractMaterialSide(left.white, right.white),
    subtractMaterialSide(left.black, right.black)
  );
}

const INITIAL_MATERIAL = Material.fromBoard(Chess.default().board);

export function capturedMaterial(board: Board): Material {
  return subtractMaterial(INITIAL_MATERIAL, Material.fromBoard(board));
}
```


With the subtract method, this code could be simplified to:

```
const INITIAL_MATERIAL = Material.fromBoard(Chess.default().board);

export function capturedMaterial(board: Board): Material {
  return INITIAL_MATERIAL.subtract(Material.fromBoard(board))
}
```
